### PR TITLE
feat: Implement dynamic alpha schedulers for RDT

### DIFF
--- a/alpha_scheduler_testing_examples.md
+++ b/alpha_scheduler_testing_examples.md
@@ -1,0 +1,154 @@
+```markdown
+# Testing New Alpha Scheduling Strategies in RDT
+
+This guide provides example command-line arguments for running experiments with each of the new alpha scheduling strategies implemented in `src/schedulers.py`. The entry point for these experiments is `main.py`.
+
+**General Advice for Testing:**
+
+*   **Small Epochs:** Use a small number of epochs (e.g., 10-20) initially to quickly observe the alpha behavior and ensure the experiment setup is correct.
+*   **Logging:** Ensure that logging is configured to show alpha values per epoch. The `main.py` script should automatically log the RDT alpha schedule if it's recorded in the training history. Check the `run_*.log` file in the `log` directory and the generated plots for alpha progression.
+*   **Dataset/Model Choice:** For dynamic schedulers like `early_stopping_based` and `control_gate`, use datasets and model combinations where you expect to see variations in student/teacher performance or validation loss behavior (e.g., a student model that might overfit or a teacher that provides a clear, but not perfect, signal). This will better test the dynamic adjustment capabilities.
+*   **Basic Arguments:** Remember to include other necessary arguments for your experiment, such as:
+    *   `--dataset_path data/your_dataset.csv`
+    *   `--teacher_model_name DLinear` (or any other model, or `None` for task-only student)
+    *   `--student_model_name PatchTST` (or any other model)
+    *   `--prediction_horizon 96`
+    *   `--lookback_window 192`
+    *   `--stability_runs 1` (to keep it quick for testing schedulers)
+
+---
+
+## 1. Fixed Weight Scheduler (`fixed`)
+
+*   **Purpose:** To verify that alpha remains constant throughout training.
+*   **Example:**
+    ```bash
+    python main.py \
+        --alpha_schedule fixed \
+        --constant_alpha 0.3 \
+        --epochs 10 \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1
+    ```
+*   **Expected Observation:** The alpha value reported in the logs and visible in the alpha schedule plot (if generated) should remain constant at 0.3 for all epochs.
+
+---
+
+## 2. Cosine Annealing Scheduler (`cosine`)
+
+*   **Purpose:** To verify that alpha follows a smooth cosine curve from a starting value to an ending value.
+*   **Example:**
+    ```bash
+    python main.py \
+        --alpha_schedule cosine \
+        --alpha_start 0.1 \
+        --alpha_end 0.9 \
+        --epochs 10 \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1
+    ```
+*   **Expected Observation:** Alpha should start at approximately 0.1 at epoch 0 and smoothly transition to approximately 0.9 by epoch 9, following a cosine annealing curve. This should be visible in the logs and the alpha schedule plot.
+
+---
+
+## 3. Early Stopping Based Scheduler (`early_stopping_based`)
+
+*   **Purpose:** To verify that alpha adjustment occurs based on validation loss stagnation.
+*   **Example (Freeze mode):**
+    ```bash
+    python main.py \
+        --alpha_schedule early_stopping_based \
+        --alpha_start 0.2 \
+        --alpha_end 0.8 \
+        --epochs 20 \
+        --es_alpha_patience 3 \
+        --es_alpha_adjust_mode freeze \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1 \
+        --patience 10 # Main model training patience
+    ```
+*   **Example (Decay to Teacher mode):**
+    ```bash
+    python main.py \
+        --alpha_schedule early_stopping_based \
+        --alpha_start 0.5 \
+        --alpha_end 0.8 \
+        --epochs 20 \
+        --es_alpha_patience 3 \
+        --es_alpha_adjust_mode decay_to_teacher \
+        --es_alpha_adjust_rate 0.05 \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1 \
+        --patience 10
+    ```
+*   **Expected Observation:** Monitor the validation loss (e.g., `val_task_loss` from RDT trainer logs). If the validation loss does not improve for `es_alpha_patience` consecutive epochs, the alpha value should change according to `es_alpha_adjust_mode`.
+    *   In `freeze` mode, alpha should become fixed at its value when patience ran out.
+    *   In `decay_to_teacher` mode, alpha should decrease by `es_alpha_adjust_rate`.
+    *   In `decay_to_student` mode (not shown in example but testable), alpha should increase.
+    The logs should explicitly state when the EarlyStoppingBasedScheduler triggers an alpha adjustment.
+
+---
+
+## 4. Control Gate Scheduler (`control_gate`)
+
+*   **Purpose:** To verify dynamic alpha adjustment based on a specified metric (e.g., model/label similarity or error).
+*   **Example (Cosine Similarity with Teacher):**
+    ```bash
+    python main.py \
+        --alpha_schedule control_gate \
+        --alpha_start 0.2 \
+        --alpha_end 0.8 \
+        --epochs 15 \
+        --control_gate_metric cosine_similarity \
+        --control_gate_threshold_low 0.6 \
+        --control_gate_threshold_high 0.85 \
+        --control_gate_alpha_adjust_rate 0.02 \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1 \
+        --patience 10
+    ```
+*   **Example (MSE Student vs True Labels):**
+    ```bash
+    python main.py \
+        --alpha_schedule control_gate \
+        --alpha_start 0.2 \
+        --alpha_end 0.8 \
+        --epochs 15 \
+        --control_gate_metric mse_student_true \
+        --control_gate_threshold_low 0.1 \
+        --control_gate_threshold_high 0.5 \
+        --control_gate_alpha_adjust_rate 0.02 \
+        --dataset_path data/national_illness.csv \
+        --teacher_model_name DLinear \
+        --student_model_name PatchTST \
+        --prediction_horizon 96 \
+        --lookback_window 192 \
+        --stability_runs 1 \
+        --patience 10
+    ```
+*   **Expected Observation:** The logs should show the calculated metric value (e.g., "ControlGateScheduler: Epoch X, Metric (cosine_similarity): Y.YYY, Alpha changed from A.AAA to B.BBB"). Verify that alpha adjusts (increases or decreases by `control_gate_alpha_adjust_rate`) when the metric value crosses the `control_gate_threshold_low` or `control_gate_threshold_high`. If the metric is between the thresholds, alpha should remain unchanged. The initial alpha for ControlGate is typically `(alpha_start + alpha_end) / 2.0`.
+
+---
+
+Remember to adapt file paths, model names, and other hyperparameters as necessary for your specific setup and the dataset being used.
+```

--- a/main.py
+++ b/main.py
@@ -309,6 +309,26 @@ def update_config_from_args(cfg, args):
     if args.teacher_model_name: cfg.TEACHER_MODEL_NAME = args.teacher_model_name if args.teacher_model_name.lower() != 'none' else None
     if args.student_model_name: cfg.STUDENT_MODEL_NAME = args.student_model_name
 
+    # --- RDT Alpha Scheduler Arguments ---
+    if args.alpha_schedule: cfg.ALPHA_SCHEDULE = args.alpha_schedule
+    if args.alpha_start is not None: cfg.ALPHA_START = args.alpha_start
+    if args.alpha_end is not None: cfg.ALPHA_END = args.alpha_end
+    if args.constant_alpha is not None: cfg.CONSTANT_ALPHA = args.constant_alpha
+
+    # --- Control Gate Scheduler Arguments ---
+    if args.control_gate_metric: cfg.CONTROL_GATE_METRIC = args.control_gate_metric
+    if args.control_gate_threshold_low is not None: cfg.CONTROL_GATE_THRESHOLD_LOW = args.control_gate_threshold_low
+    if args.control_gate_threshold_high is not None: cfg.CONTROL_GATE_THRESHOLD_HIGH = args.control_gate_threshold_high
+    if args.control_gate_alpha_adjust_rate is not None: cfg.CONTROL_GATE_ALPHA_ADJUST_RATE = args.control_gate_alpha_adjust_rate
+    if args.control_gate_target_similarity is not None: cfg.CONTROL_GATE_TARGET_SIMILARITY = args.control_gate_target_similarity
+    if args.control_gate_mse_student_target is not None: cfg.CONTROL_GATE_MSE_STUDENT_TARGET = args.control_gate_mse_student_target
+
+    # --- Early Stopping Based Scheduler Arguments ---
+    if args.es_alpha_patience is not None: cfg.ES_ALPHA_PATIENCE = args.es_alpha_patience
+    if args.es_alpha_adjust_mode: cfg.ES_ALPHA_ADJUST_MODE = args.es_alpha_adjust_mode
+    if args.es_alpha_adjust_rate is not None: cfg.ES_ALPHA_ADJUST_RATE = args.es_alpha_adjust_rate
+
+
     # Update dependent configs - Needs to be more robust if models change
     # This assumes TEACHER_CONFIG and STUDENT_CONFIG exist and have these keys
     if hasattr(cfg, 'TEACHER_CONFIG') and cfg.TEACHER_CONFIG:
@@ -499,6 +519,38 @@ if __name__ == "__main__":
                         help=f'Name of the teacher model (e.g., DLinear, PatchTST, None) (default: {default_config.TEACHER_MODEL_NAME})')
     parser.add_argument('--student_model_name', type=str, default=default_config.STUDENT_MODEL_NAME,
                         help=f'Name of the student model (e.g., PatchTST, DLinear) (default: {default_config.STUDENT_MODEL_NAME})')
+
+    # --- RDT Alpha Scheduler Arguments ---
+    parser.add_argument('--alpha_schedule', type=str, default=default_config.ALPHA_SCHEDULE,
+                        help=f'Alpha schedule type (linear, cosine, fixed, early_stopping_based, control_gate) (default: {default_config.ALPHA_SCHEDULE})')
+    parser.add_argument('--alpha_start', type=float, default=default_config.ALPHA_START,
+                        help=f'Starting alpha value for linear/cosine schedules (default: {default_config.ALPHA_START})')
+    parser.add_argument('--alpha_end', type=float, default=default_config.ALPHA_END,
+                        help=f'Ending alpha value for linear/cosine schedules (default: {default_config.ALPHA_END})')
+    parser.add_argument('--constant_alpha', type=float, default=default_config.CONSTANT_ALPHA,
+                        help=f'Constant alpha value for fixed schedule (default: {default_config.CONSTANT_ALPHA})')
+
+    # --- Control Gate Scheduler Arguments ---
+    parser.add_argument('--control_gate_metric', type=str, default=default_config.CONTROL_GATE_METRIC,
+                        help=f'Metric for control gate (cosine_similarity, mse_student_true, mse_student_teacher) (default: {default_config.CONTROL_GATE_METRIC})')
+    parser.add_argument('--control_gate_threshold_low', type=float, default=default_config.CONTROL_GATE_THRESHOLD_LOW,
+                        help=f'Lower threshold for control gate (default: {default_config.CONTROL_GATE_THRESHOLD_LOW})')
+    parser.add_argument('--control_gate_threshold_high', type=float, default=default_config.CONTROL_GATE_THRESHOLD_HIGH,
+                        help=f'Higher threshold for control gate (default: {default_config.CONTROL_GATE_THRESHOLD_HIGH})')
+    parser.add_argument('--control_gate_alpha_adjust_rate', type=float, default=default_config.CONTROL_GATE_ALPHA_ADJUST_RATE,
+                        help=f'Alpha adjustment rate for control gate (default: {default_config.CONTROL_GATE_ALPHA_ADJUST_RATE})')
+    parser.add_argument('--control_gate_target_similarity', type=float, default=default_config.CONTROL_GATE_TARGET_SIMILARITY,
+                        help=f'Target similarity for control gate (optional) (default: {default_config.CONTROL_GATE_TARGET_SIMILARITY})')
+    parser.add_argument('--control_gate_mse_student_target', type=float, default=default_config.CONTROL_GATE_MSE_STUDENT_TARGET,
+                        help=f'Target MSE for student vs true for control gate (optional) (default: {default_config.CONTROL_GATE_MSE_STUDENT_TARGET})')
+
+    # --- Early Stopping Based Scheduler Arguments ---
+    parser.add_argument('--es_alpha_patience', type=int, default=default_config.ES_ALPHA_PATIENCE,
+                        help=f'Patience for early stopping based alpha scheduler (default: {default_config.ES_ALPHA_PATIENCE})')
+    parser.add_argument('--es_alpha_adjust_mode', type=str, default=default_config.ES_ALPHA_ADJUST_MODE,
+                        help=f'Alpha adjustment mode for early stopping (freeze, decay_to_teacher, decay_to_student) (default: {default_config.ES_ALPHA_ADJUST_MODE})')
+    parser.add_argument('--es_alpha_adjust_rate', type=float, default=default_config.ES_ALPHA_ADJUST_RATE,
+                        help=f'Alpha adjustment rate for early stopping decay modes (default: {default_config.ES_ALPHA_ADJUST_RATE})')
 
     args = parser.parse_args()
     main(args)

--- a/src/config.py
+++ b/src/config.py
@@ -60,10 +60,26 @@ class Config:
         self.USE_AMP = True # Enable Automatic Mixed Precision (AMP)
 
         # --- RDT 配置 ---
+        # ALPHA_SCHEDULE options: 'linear', 'cosine', 'fixed', 'early_stopping_based', 'control_gate'
         self.ALPHA_START = 0.3
         self.ALPHA_END = 0.7
-        self.ALPHA_SCHEDULE = 'linear'
+        self.ALPHA_SCHEDULE = 'linear' 
         self.CONSTANT_ALPHA = 0.5
+
+        # --- Control Gate Scheduler Parameters ---
+        # Metric options: 'cosine_similarity', 'mse_student_true', 'mse_student_teacher'
+        self.CONTROL_GATE_METRIC = 'cosine_similarity' 
+        self.CONTROL_GATE_THRESHOLD_LOW = 0.5
+        self.CONTROL_GATE_THRESHOLD_HIGH = 0.8
+        self.CONTROL_GATE_ALPHA_ADJUST_RATE = 0.01
+        self.CONTROL_GATE_TARGET_SIMILARITY = 0.7  # Optional: for proportional control
+        self.CONTROL_GATE_MSE_STUDENT_TARGET = 0.1 # Optional: target MSE for student vs true
+
+        # --- Early Stopping Based Scheduler Parameters ---
+        self.ES_ALPHA_PATIENCE = 5 # Epochs with no val_loss improvement before adjusting alpha
+        # ES_ALPHA_ADJUST_MODE options: 'freeze', 'decay_to_teacher', 'decay_to_student'
+        self.ES_ALPHA_ADJUST_MODE = 'freeze' 
+        self.ES_ALPHA_ADJUST_RATE = 0.01 # Used if mode is decay
 
         # --- 评估配置 ---
         self.METRICS = ['mae', 'mse']

--- a/src/schedulers.py
+++ b/src/schedulers.py
@@ -1,4 +1,14 @@
 import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn.metrics import mean_squared_error as mse_sklearn # For ControlGateScheduler if needed
+# Attempt to import project-specific cosine_similarity, fall back if not found
+try:
+    from src.evaluator import cosine_similarity as cosine_similarity_project
+except ImportError:
+    cosine_similarity_project = None
+    print("Warning: src.evaluator.cosine_similarity not found. ControlGateScheduler using 'cosine_similarity' might fail if not using PyTorch's version.")
+
 
 class BaseAlphaScheduler:
     def __init__(self, alpha_start, alpha_end, total_epochs):
@@ -9,16 +19,17 @@ class BaseAlphaScheduler:
     def get_alpha(self, current_epoch):
         raise NotImplementedError
 
-    def update(self, current_epoch, val_loss, student_preds, teacher_preds, true_labels):
+    def update(self, current_epoch, val_loss=None, student_preds=None, teacher_preds=None, true_labels=None, student_model=None):
         """
         根据验证集信息（如验证损失、模型预测）动态调整 alpha。
         此方法在基类中默认不实现，由需要动态调整的子类实现。
         参数:
             current_epoch (int): 当前的 epoch 编号。
-            val_loss (float): 当前 epoch 的验证损失。
-            student_preds (torch.Tensor): 学生模型在验证集上的预测结果。
-            teacher_preds (torch.Tensor): 教师模型在验证集上的预测结果。
-            true_labels (torch.Tensor): 验证集上的真实标签。
+            val_loss (float, optional): 当前 epoch 的验证损失。
+            student_preds (torch.Tensor, optional): 学生模型在验证集上的预测结果。
+            teacher_preds (torch.Tensor, optional): 教师模型在验证集上的预测结果。
+            true_labels (torch.Tensor, optional): 验证集上的真实标签。
+            student_model (torch.nn.Module, optional): 学生模型实例，用于某些调度器。
         """
         pass # 默认不执行任何操作
 
@@ -31,9 +42,10 @@ class ConstantScheduler(BaseAlphaScheduler):
     def get_alpha(self, current_epoch):
         return self.alpha_value
 
-    def update(self, current_epoch, val_loss, student_preds, teacher_preds, true_labels):
-        # 对于固定调度器，update 方法不执行任何操作
-        pass
+class FixedWeightScheduler(ConstantScheduler):
+    def __init__(self, alpha_value, total_epochs):
+        super().__init__(alpha_value, total_epochs)
+        print(f"Using Fixed Weight Alpha Scheduler with alpha = {self.alpha_value}")
 
 class LinearScheduler(BaseAlphaScheduler):
     def __init__(self, alpha_start, alpha_end, total_epochs):
@@ -48,9 +60,22 @@ class LinearScheduler(BaseAlphaScheduler):
         alpha = self.alpha_start + (self.alpha_end - self.alpha_start) * progress
         return alpha
 
-    def update(self, current_epoch, val_loss, student_preds, teacher_preds, true_labels):
+    def update(self, current_epoch, val_loss=None, student_preds=None, teacher_preds=None, true_labels=None, student_model=None):
         # 对于线性调度器，update 方法不执行任何操作
         pass
+
+class CosineAnnealingScheduler(BaseAlphaScheduler):
+    def __init__(self, alpha_start, alpha_end, total_epochs):
+        super().__init__(alpha_start, alpha_end, total_epochs)
+        print(f"Using Cosine Annealing Alpha Scheduler: start={alpha_start}, end={alpha_end}, epochs={total_epochs}")
+
+    def get_alpha(self, current_epoch):
+        if self.total_epochs <= 1:
+            return self.alpha_end
+        progress = min(current_epoch / (self.total_epochs - 1), 1.0)
+        # 使用余弦退火公式
+        alpha = self.alpha_end + 0.5 * (self.alpha_start - self.alpha_end) * (1 + np.cos(np.pi * progress))
+        return alpha
 
 class ExponentialScheduler(BaseAlphaScheduler):
     def __init__(self, alpha_start, alpha_end, total_epochs):
@@ -76,9 +101,129 @@ class ExponentialScheduler(BaseAlphaScheduler):
         # 限制 alpha 不超过 alpha_end (防止浮点误差导致略微超出)
         return min(alpha, self.alpha_end) if self.rate > 1.0 else max(alpha, self.alpha_end)
 
-    def update(self, current_epoch, val_loss, student_preds, teacher_preds, true_labels):
+    def update(self, current_epoch, val_loss=None, student_preds=None, teacher_preds=None, true_labels=None, student_model=None):
         # 对于指数调度器，update 方法不执行任何操作
         pass
+
+class EarlyStoppingBasedScheduler(BaseAlphaScheduler):
+    def __init__(self, config, total_epochs):
+        super().__init__(config.ALPHA_START, config.ALPHA_END, total_epochs)
+        self.es_alpha_patience = config.ES_ALPHA_PATIENCE
+        self.es_alpha_adjust_mode = config.ES_ALPHA_ADJUST_MODE.lower()
+        self.es_alpha_adjust_rate = config.ES_ALPHA_ADJUST_RATE
+        
+        self.current_alpha = config.ALPHA_START # Initial alpha
+        self.patience_counter = 0
+        self.best_val_loss = float('inf')
+        self.frozen = False # Flag to indicate if alpha is frozen
+
+        print(f"Using Early Stopping Based Alpha Scheduler: initial_alpha={self.current_alpha}, patience={self.es_alpha_patience}, mode='{self.es_alpha_adjust_mode}', rate={self.es_alpha_adjust_rate}")
+
+    def get_alpha(self, current_epoch):
+        # Optionally, could have an underlying linear/cosine progression here if not frozen
+        # For now, it's either the initial alpha or the adjusted alpha
+        return self.current_alpha
+
+    def update(self, current_epoch, val_loss=None, student_preds=None, teacher_preds=None, true_labels=None, student_model=None):
+        if self.frozen:
+            return
+
+        if val_loss is None:
+            print("Warning: EarlyStoppingBasedScheduler requires val_loss for updates.")
+            return
+
+        if val_loss < self.best_val_loss:
+            self.best_val_loss = val_loss
+            self.patience_counter = 0
+        else:
+            self.patience_counter += 1
+
+        if self.patience_counter >= self.es_alpha_patience:
+            print(f"EarlyStoppingBasedScheduler: Patience triggered at epoch {current_epoch}. Adjusting alpha.")
+            if self.es_alpha_adjust_mode == 'freeze':
+                self.frozen = True
+                print(f"Alpha frozen at {self.current_alpha}")
+            elif self.es_alpha_adjust_mode == 'decay_to_teacher': # Trust teacher more
+                self.current_alpha = max(0.0, self.current_alpha - self.es_alpha_adjust_rate)
+                print(f"Alpha decayed towards teacher, new alpha: {self.current_alpha}")
+            elif self.es_alpha_adjust_mode == 'decay_to_student': # Trust student more
+                self.current_alpha = min(1.0, self.current_alpha + self.es_alpha_adjust_rate)
+                print(f"Alpha decayed towards student, new alpha: {self.current_alpha}")
+            else:
+                print(f"Warning: Unknown ES_ALPHA_ADJUST_MODE '{self.es_alpha_adjust_mode}'. Alpha not changed.")
+            self.patience_counter = 0 # Reset patience after adjustment
+
+class ControlGateScheduler(BaseAlphaScheduler):
+    def __init__(self, config, total_epochs):
+        super().__init__(config.ALPHA_START, config.ALPHA_END, total_epochs)
+        self.metric_name = config.CONTROL_GATE_METRIC.lower()
+        self.threshold_low = config.CONTROL_GATE_THRESHOLD_LOW
+        self.threshold_high = config.CONTROL_GATE_THRESHOLD_HIGH
+        self.adjust_rate = config.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.target_similarity = config.CONTROL_GATE_TARGET_SIMILARITY # Optional
+        self.target_mse_student = config.CONTROL_GATE_MSE_STUDENT_TARGET # Optional
+
+        # Initialize alpha: could be start, end, or average
+        self.current_alpha = (config.ALPHA_START + config.ALPHA_END) / 2.0 
+        print(f"Using Control Gate Alpha Scheduler: initial_alpha={self.current_alpha}, metric='{self.metric_name}', low_thresh={self.threshold_low}, high_thresh={self.threshold_high}, rate={self.adjust_rate}")
+
+    def get_alpha(self, current_epoch):
+        return self.current_alpha
+
+    def _calculate_metric(self, student_preds, teacher_preds, true_labels):
+        if student_preds is None: return None # Cannot calculate if student preds are missing
+
+        # Ensure tensors are on CPU and converted to numpy if using sklearn/numpy functions
+        # For PyTorch functions, ensure they are on the same device
+        
+        # Flatten predictions for metric calculation (batch_size * horizon, num_features)
+        # Assuming student_preds, teacher_preds, true_labels are [batch, horizon, features]
+        s_preds_flat = student_preds.reshape(-1, student_preds.shape[-1])
+        
+        if self.metric_name == 'cosine_similarity':
+            if teacher_preds is None: return None
+            t_preds_flat = teacher_preds.reshape(-1, teacher_preds.shape[-1])
+            # Using torch.nn.functional.cosine_similarity
+            # Ensure inputs are float
+            sim = F.cosine_similarity(s_preds_flat.float(), t_preds_flat.float(), dim=-1).mean().item()
+            return sim
+        elif self.metric_name == 'mse_student_true':
+            if true_labels is None: return None
+            true_labels_flat = true_labels.reshape(-1, true_labels.shape[-1])
+            mse = F.mse_loss(s_preds_flat.float(), true_labels_flat.float()).item()
+            return mse
+        elif self.metric_name == 'mse_student_teacher':
+            if teacher_preds is None: return None
+            t_preds_flat = teacher_preds.reshape(-1, teacher_preds.shape[-1])
+            mse = F.mse_loss(s_preds_flat.float(), t_preds_flat.float()).item()
+            return mse
+        else:
+            print(f"Warning: Unknown ControlGate metric '{self.metric_name}'.")
+            return None
+
+    def update(self, current_epoch, val_loss=None, student_preds=None, teacher_preds=None, true_labels=None, student_model=None):
+        metric_val = self._calculate_metric(student_preds, teacher_preds, true_labels)
+
+        if metric_val is None:
+            print(f"ControlGateScheduler: Metric calculation failed or inputs missing at epoch {current_epoch}. Alpha not changed.")
+            return
+
+        prev_alpha = self.current_alpha
+        if self.metric_name == 'cosine_similarity': # Higher is better
+            if metric_val < self.threshold_low: # Student is too different from teacher
+                self.current_alpha = max(0.0, self.current_alpha - self.adjust_rate) # Trust teacher more
+            elif metric_val > self.threshold_high: # Student is very similar to teacher
+                self.current_alpha = min(1.0, self.current_alpha + self.adjust_rate) # Trust student more (task loss)
+        elif 'mse' in self.metric_name: # Lower is better
+            if metric_val > self.threshold_high: # Error is too high
+                self.current_alpha = max(0.0, self.current_alpha - self.adjust_rate) # Trust teacher more
+            elif metric_val < self.threshold_low: # Error is very low
+                self.current_alpha = min(1.0, self.current_alpha + self.adjust_rate) # Trust student/task more
+        
+        if prev_alpha != self.current_alpha:
+            print(f"ControlGateScheduler: Epoch {current_epoch}, Metric ({self.metric_name}): {metric_val:.4f}, Alpha changed from {prev_alpha:.4f} to {self.current_alpha:.4f}")
+        else:
+            print(f"ControlGateScheduler: Epoch {current_epoch}, Metric ({self.metric_name}): {metric_val:.4f}, Alpha remains {self.current_alpha:.4f}")
 
 
 def get_alpha_scheduler(cfg):
@@ -86,20 +231,24 @@ def get_alpha_scheduler(cfg):
     schedule_type = cfg.ALPHA_SCHEDULE.lower()
     if schedule_type == 'linear':
         return LinearScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
+    elif schedule_type == 'cosine':
+        return CosineAnnealingScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
     elif schedule_type == 'exponential':
-        # 指数增长通常要求 alpha > 0，如果 alpha_start=0，可能需要调整
-        start_alpha = cfg.ALPHA_START if cfg.ALPHA_START > 0 else 1e-6 # 避免 log(0) 或除以 0
+        start_alpha = cfg.ALPHA_START if cfg.ALPHA_START > 0 else 1e-6 
         end_alpha = cfg.ALPHA_END
-        if end_alpha <= start_alpha and end_alpha > 0: # 处理非增长情况
+        if end_alpha <= start_alpha and end_alpha > 0:
              print("Warning: ExponentialScheduler with non-increasing alpha, behaving like constant at start.")
-             return ConstantScheduler(start_alpha, cfg.EPOCHS)
+             return ConstantScheduler(start_alpha, cfg.EPOCHS) # Or FixedWeightScheduler
         elif end_alpha <= 0:
              print("Warning: ExponentialScheduler end alpha <= 0, defaulting to linear.")
              return LinearScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
-
         return ExponentialScheduler(start_alpha, end_alpha, cfg.EPOCHS)
-    elif schedule_type == 'constant':
-        return ConstantScheduler(cfg.CONSTANT_ALPHA, cfg.EPOCHS)
+    elif schedule_type == 'constant' or schedule_type == 'fixed': # Added 'fixed'
+        return FixedWeightScheduler(cfg.CONSTANT_ALPHA, cfg.EPOCHS)
+    elif schedule_type == 'early_stopping_based':
+        return EarlyStoppingBasedScheduler(cfg, cfg.EPOCHS)
+    elif schedule_type == 'control_gate':
+        return ControlGateScheduler(cfg, cfg.EPOCHS)
     else:
         raise ValueError(f"Unsupported alpha schedule type: {schedule_type}")
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -1,0 +1,358 @@
+import unittest
+import torch
+import numpy as np
+from src.schedulers import (
+    BaseAlphaScheduler,
+    ConstantScheduler,
+    FixedWeightScheduler,
+    LinearScheduler,
+    CosineAnnealingScheduler,
+    ExponentialScheduler,
+    EarlyStoppingBasedScheduler,
+    ControlGateScheduler,
+    get_alpha_scheduler
+)
+
+# Mock Config class to simulate the main Config object
+class MockConfig:
+    def __init__(self):
+        # General
+        self.EPOCHS = 10
+        self.ALPHA_START = 0.1
+        self.ALPHA_END = 0.9
+        self.CONSTANT_ALPHA = 0.5
+        self.ALPHA_SCHEDULE = 'linear' # Default, can be changed per test
+
+        # EarlyStoppingBasedScheduler
+        self.ES_ALPHA_PATIENCE = 3
+        self.ES_ALPHA_ADJUST_MODE = 'freeze' # 'freeze', 'decay_to_teacher', 'decay_to_student'
+        self.ES_ALPHA_ADJUST_RATE = 0.01
+
+        # ControlGateScheduler
+        self.CONTROL_GATE_METRIC = 'cosine_similarity' # 'mse_student_true', 'mse_student_teacher'
+        self.CONTROL_GATE_THRESHOLD_LOW = 0.5
+        self.CONTROL_GATE_THRESHOLD_HIGH = 0.8
+        self.CONTROL_GATE_ALPHA_ADJUST_RATE = 0.05
+        self.CONTROL_GATE_TARGET_SIMILARITY = 0.7 # Optional
+        self.CONTROL_GATE_MSE_STUDENT_TARGET = 0.1 # Optional
+
+
+class TestFixedWeightScheduler(unittest.TestCase):
+    def test_initialization_and_get_alpha(self):
+        cfg = MockConfig()
+        cfg.CONSTANT_ALPHA = 0.6
+        scheduler = FixedWeightScheduler(alpha_value=cfg.CONSTANT_ALPHA, total_epochs=cfg.EPOCHS)
+        self.assertEqual(scheduler.alpha_value, 0.6)
+        for epoch in range(cfg.EPOCHS):
+            self.assertEqual(scheduler.get_alpha(epoch), 0.6)
+
+class TestCosineAnnealingScheduler(unittest.TestCase):
+    def test_alpha_progression(self):
+        cfg = MockConfig()
+        cfg.ALPHA_START = 0.0
+        cfg.ALPHA_END = 1.0
+        cfg.EPOCHS = 11 # Use 11 epochs for 0 to 10, easier mid-point
+        scheduler = CosineAnnealingScheduler(alpha_start=cfg.ALPHA_START, alpha_end=cfg.ALPHA_END, total_epochs=cfg.EPOCHS)
+
+        # Alpha at start (epoch 0) should be alpha_start
+        self.assertAlmostEqual(scheduler.get_alpha(0), cfg.ALPHA_START, places=6)
+
+        # Alpha at mid (epoch 5 for 11 total epochs, progress = 0.5)
+        # cos(pi * 0.5) = 0. So, alpha = alpha_end + 0.5 * (alpha_start - alpha_end) * (1 + 0)
+        # alpha = alpha_end + 0.5 * alpha_start - 0.5 * alpha_end = 0.5 * (alpha_start + alpha_end)
+        expected_mid_alpha = cfg.ALPHA_END + 0.5 * (cfg.ALPHA_START - cfg.ALPHA_END) * (1 + np.cos(np.pi * 0.5))
+        self.assertAlmostEqual(scheduler.get_alpha(cfg.EPOCHS // 2), expected_mid_alpha, places=6)
+
+
+        # Alpha at end (epoch 10) should be alpha_end
+        self.assertAlmostEqual(scheduler.get_alpha(cfg.EPOCHS - 1), cfg.ALPHA_END, places=6)
+
+    def test_single_epoch(self):
+        scheduler = CosineAnnealingScheduler(alpha_start=0.1, alpha_end=0.9, total_epochs=1)
+        self.assertAlmostEqual(scheduler.get_alpha(0), 0.9, places=6)
+
+
+class TestEarlyStoppingBasedScheduler(unittest.TestCase):
+    def setUp(self):
+        self.cfg = MockConfig()
+        self.total_epochs = self.cfg.EPOCHS
+
+    def test_initialization(self):
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        self.assertEqual(scheduler.current_alpha, self.cfg.ALPHA_START)
+        self.assertEqual(scheduler.es_alpha_patience, self.cfg.ES_ALPHA_PATIENCE)
+        self.assertEqual(scheduler.es_alpha_adjust_mode, self.cfg.ES_ALPHA_ADJUST_MODE)
+        self.assertEqual(scheduler.es_alpha_adjust_rate, self.cfg.ES_ALPHA_ADJUST_RATE)
+        self.assertEqual(scheduler.patience_counter, 0)
+        self.assertEqual(scheduler.best_val_loss, float('inf'))
+        self.assertFalse(scheduler.frozen)
+
+    def test_val_loss_improves(self):
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        initial_alpha = scheduler.get_alpha(0)
+        val_loss = 1.0
+        for epoch in range(self.cfg.ES_ALPHA_PATIENCE + 1):
+            val_loss *= 0.9 # Consistent improvement
+            scheduler.update(epoch, val_loss=val_loss)
+            self.assertEqual(scheduler.get_alpha(epoch), initial_alpha)
+            self.assertEqual(scheduler.patience_counter, 0)
+        self.assertFalse(scheduler.frozen)
+
+    def test_patience_increments(self):
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        scheduler.update(0, val_loss=1.0) # Initial best loss
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE):
+            scheduler.update(epoch, val_loss=1.1) # No improvement
+            self.assertEqual(scheduler.patience_counter, epoch)
+            self.assertEqual(scheduler.get_alpha(epoch), self.cfg.ALPHA_START)
+        self.assertFalse(scheduler.frozen)
+
+    def test_patience_runs_out_freeze_mode(self):
+        self.cfg.ES_ALPHA_ADJUST_MODE = 'freeze'
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        scheduler.update(0, val_loss=1.0)
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE):
+            scheduler.update(epoch, val_loss=1.1) # No improvement
+
+        # Trigger adjustment
+        scheduler.update(self.cfg.ES_ALPHA_PATIENCE, val_loss=1.1)
+        self.assertTrue(scheduler.frozen)
+        alpha_after_freeze = scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE)
+        self.assertEqual(alpha_after_freeze, self.cfg.ALPHA_START)
+        # Further updates should not change alpha
+        scheduler.update(self.cfg.ES_ALPHA_PATIENCE + 1, val_loss=0.5) # Improvement
+        self.assertEqual(scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE+1), alpha_after_freeze)
+
+    def test_patience_runs_out_decay_to_teacher_mode(self):
+        self.cfg.ES_ALPHA_ADJUST_MODE = 'decay_to_teacher'
+        self.cfg.ALPHA_START = 0.5 # Start somewhere in the middle
+        self.cfg.ES_ALPHA_ADJUST_RATE = 0.1
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        initial_alpha = scheduler.current_alpha
+
+        scheduler.update(0, val_loss=1.0)
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE +1 ): # Reach patience trigger
+            scheduler.update(epoch, val_loss=1.1)
+
+        expected_alpha = initial_alpha - self.cfg.ES_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE), expected_alpha, places=6)
+        self.assertEqual(scheduler.patience_counter, 0) # Resets after adjustment
+
+        # Test boundary (not going below 0)
+        scheduler.current_alpha = 0.05 # Set alpha close to 0
+        scheduler.best_val_loss = 0.5 # Reset best loss
+        scheduler.update(0, val_loss=0.5)
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE + 1):
+            scheduler.update(epoch, val_loss=0.6)
+        self.assertAlmostEqual(scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE), 0.0, places=6)
+
+
+    def test_patience_runs_out_decay_to_student_mode(self):
+        self.cfg.ES_ALPHA_ADJUST_MODE = 'decay_to_student'
+        self.cfg.ALPHA_START = 0.5 # Start somewhere in the middle
+        self.cfg.ES_ALPHA_ADJUST_RATE = 0.1
+        scheduler = EarlyStoppingBasedScheduler(self.cfg, self.total_epochs)
+        initial_alpha = scheduler.current_alpha
+
+        scheduler.update(0, val_loss=1.0)
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE +1 ): # Reach patience trigger
+            scheduler.update(epoch, val_loss=1.1)
+
+        expected_alpha = initial_alpha + self.cfg.ES_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE), expected_alpha, places=6)
+
+        # Test boundary (not going above 1)
+        scheduler.current_alpha = 0.95 # Set alpha close to 1
+        scheduler.best_val_loss = 0.5 # Reset best loss
+        scheduler.update(0, val_loss=0.5)
+        for epoch in range(1, self.cfg.ES_ALPHA_PATIENCE + 1):
+            scheduler.update(epoch, val_loss=0.6)
+        self.assertAlmostEqual(scheduler.get_alpha(self.cfg.ES_ALPHA_PATIENCE), 1.0, places=6)
+
+
+class TestControlGateScheduler(unittest.TestCase):
+    def setUp(self):
+        self.cfg = MockConfig()
+        self.total_epochs = self.cfg.EPOCHS
+        # Dummy tensors (batch_size, sequence_length, num_features)
+        self.student_preds = torch.randn(16, 20, 5)
+        self.teacher_preds = torch.randn(16, 20, 5)
+        self.true_labels = torch.randn(16, 20, 5)
+        # Initial alpha is usually (alpha_start + alpha_end) / 2
+        self.initial_alpha = (self.cfg.ALPHA_START + self.cfg.ALPHA_END) / 2.0
+
+    def test_initialization(self):
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        self.assertAlmostEqual(scheduler.current_alpha, self.initial_alpha, places=6)
+        self.assertEqual(scheduler.metric_name, self.cfg.CONTROL_GATE_METRIC)
+        self.assertEqual(scheduler.threshold_low, self.cfg.CONTROL_GATE_THRESHOLD_LOW)
+        self.assertEqual(scheduler.threshold_high, self.cfg.CONTROL_GATE_THRESHOLD_HIGH)
+        self.assertEqual(scheduler.adjust_rate, self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE)
+
+    def test_metric_cosine_similarity(self):
+        self.cfg.CONTROL_GATE_METRIC = 'cosine_similarity'
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        self.assertEqual(scheduler.metric_name, 'cosine_similarity')
+
+        # Scenario 1: Metric below threshold_low (alpha decreases)
+        # Mock _calculate_metric to return a low similarity
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_LOW - 0.1
+        scheduler.update(0, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        expected_alpha = self.initial_alpha - self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(0), expected_alpha, places=6)
+
+        # Scenario 2: Metric above threshold_high (alpha increases)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_HIGH + 0.1
+        scheduler.update(1, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        expected_alpha = self.initial_alpha + self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(1), expected_alpha, places=6)
+
+        # Scenario 3: Metric between thresholds (alpha unchanged)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: (self.cfg.CONTROL_GATE_THRESHOLD_LOW + self.cfg.CONTROL_GATE_THRESHOLD_HIGH) / 2
+        scheduler.update(2, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        self.assertAlmostEqual(scheduler.get_alpha(2), self.initial_alpha, places=6)
+
+    def test_metric_mse_student_true(self):
+        self.cfg.CONTROL_GATE_METRIC = 'mse_student_true'
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        self.assertEqual(scheduler.metric_name, 'mse_student_true')
+
+        # Scenario 1: MSE above threshold_high (bad MSE, alpha decreases)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_HIGH + 0.1
+        scheduler.update(0, student_preds=self.student_preds, true_labels=self.true_labels)
+        expected_alpha = self.initial_alpha - self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(0), expected_alpha, places=6)
+
+        # Scenario 2: MSE below threshold_low (good MSE, alpha increases)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_LOW - 0.1
+        scheduler.update(1, student_preds=self.student_preds, true_labels=self.true_labels)
+        expected_alpha = self.initial_alpha + self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(1), expected_alpha, places=6)
+
+    def test_metric_mse_student_teacher(self):
+        self.cfg.CONTROL_GATE_METRIC = 'mse_student_teacher'
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        self.assertEqual(scheduler.metric_name, 'mse_student_teacher')
+
+        # Scenario 1: MSE above threshold_high (bad MSE, alpha decreases)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_HIGH + 0.1
+        scheduler.update(0, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        expected_alpha = self.initial_alpha - self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(0), expected_alpha, places=6)
+
+        # Scenario 2: MSE below threshold_low (good MSE, alpha increases)
+        scheduler.current_alpha = self.initial_alpha # Reset alpha
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_LOW - 0.1
+        scheduler.update(1, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        expected_alpha = self.initial_alpha + self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE
+        self.assertAlmostEqual(scheduler.get_alpha(1), expected_alpha, places=6)
+
+    def test_alpha_boundaries(self):
+        self.cfg.CONTROL_GATE_METRIC = 'cosine_similarity'
+        self.cfg.CONTROL_GATE_ALPHA_ADJUST_RATE = 0.6 # Large rate for easier boundary check
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        
+        # Test not going below 0
+        scheduler.current_alpha = 0.1 # Start close to 0
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_LOW - 0.1 # Decrease alpha
+        scheduler.update(0, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        self.assertAlmostEqual(scheduler.get_alpha(0), 0.0, places=6)
+
+        # Test not going above 1
+        scheduler.current_alpha = 0.9 # Start close to 1
+        scheduler._calculate_metric = lambda sp, tp, tl: self.cfg.CONTROL_GATE_THRESHOLD_HIGH + 0.1 # Increase alpha
+        scheduler.update(1, student_preds=self.student_preds, teacher_preds=self.teacher_preds)
+        self.assertAlmostEqual(scheduler.get_alpha(1), 1.0, places=6)
+
+    def test_real_metric_calculation_cosine(self):
+        # Test with actual cosine similarity calculation
+        self.cfg.CONTROL_GATE_METRIC = 'cosine_similarity'
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+        
+        # Student and teacher are identical
+        preds = torch.ones_like(self.student_preds)
+        metric_val = scheduler._calculate_metric(preds, preds, self.true_labels)
+        self.assertAlmostEqual(metric_val, 1.0, places=5) # Cosine sim should be 1
+
+        # Student and teacher are orthogonal (on average for random)
+        # This is harder to guarantee orthogonality for random tensors to be exactly 0.
+        # Instead, we'll check if the update logic is called.
+        # We can create specific vectors for this if needed.
+        s_preds = torch.tensor([[[1.0, 0.0]]]).float()
+        t_preds = torch.tensor([[[0.0, 1.0]]]).float()
+        metric_val = scheduler._calculate_metric(s_preds, t_preds, None)
+        self.assertAlmostEqual(metric_val, 0.0, places=5) # Cosine sim should be 0
+
+    def test_real_metric_calculation_mse(self):
+        self.cfg.CONTROL_GATE_METRIC = 'mse_student_true'
+        scheduler = ControlGateScheduler(self.cfg, self.total_epochs)
+
+        # Student and true are identical
+        preds = torch.ones_like(self.student_preds)
+        metric_val = scheduler._calculate_metric(preds, self.teacher_preds, preds) # teacher_preds not used here
+        self.assertAlmostEqual(metric_val, 0.0, places=5) # MSE should be 0
+
+        # Student and true are different
+        s_preds = torch.ones_like(self.student_preds)
+        t_labels = torch.zeros_like(self.student_preds)
+        metric_val = scheduler._calculate_metric(s_preds, self.teacher_preds, t_labels)
+        self.assertAlmostEqual(metric_val, 1.0, places=5) # MSE should be 1 if preds are 1 and labels are 0
+
+
+class TestGetAlphaScheduler(unittest.TestCase):
+    def setUp(self):
+        self.cfg = MockConfig()
+
+    def test_get_linear(self):
+        self.cfg.ALPHA_SCHEDULE = 'linear'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, LinearScheduler)
+
+    def test_get_cosine(self):
+        self.cfg.ALPHA_SCHEDULE = 'cosine'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, CosineAnnealingScheduler)
+
+    def test_get_exponential(self):
+        self.cfg.ALPHA_SCHEDULE = 'exponential'
+        self.cfg.ALPHA_START = 0.1 # Ensure > 0 for exponential
+        self.cfg.ALPHA_END = 0.9
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, ExponentialScheduler)
+
+    def test_get_fixed(self):
+        self.cfg.ALPHA_SCHEDULE = 'fixed'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, FixedWeightScheduler)
+        self.assertEqual(scheduler.alpha_value, self.cfg.CONSTANT_ALPHA)
+
+    def test_get_constant(self): # 'constant' is an alias for 'fixed'
+        self.cfg.ALPHA_SCHEDULE = 'constant'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, FixedWeightScheduler) # Currently FixedWeightScheduler is returned
+        self.assertEqual(scheduler.alpha_value, self.cfg.CONSTANT_ALPHA)
+
+
+    def test_get_early_stopping(self):
+        self.cfg.ALPHA_SCHEDULE = 'early_stopping_based'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, EarlyStoppingBasedScheduler)
+
+    def test_get_control_gate(self):
+        self.cfg.ALPHA_SCHEDULE = 'control_gate'
+        scheduler = get_alpha_scheduler(self.cfg)
+        self.assertIsInstance(scheduler, ControlGateScheduler)
+
+    def test_get_invalid(self):
+        self.cfg.ALPHA_SCHEDULE = 'invalid_scheduler_type'
+        with self.assertRaises(ValueError):
+            get_alpha_scheduler(self.cfg)
+
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
Introduces new alpha scheduling strategies for Relational Distillation Training (RDT) to provide more flexible control over the balance between task loss (student vs. true labels) and distillation loss (student vs. teacher).

New Schedulers:
- FixedWeightScheduler: Maintains a constant alpha value (alias for ConstantScheduler).
- CosineAnnealingScheduler: Varies alpha along a cosine curve.
- EarlyStoppingBasedScheduler: Adjusts alpha's behavior based on validation loss stagnation. Modes include freezing alpha, or decaying it towards favoring the teacher or the student.
- ControlGateScheduler: Dynamically adjusts alpha based on metrics like cosine similarity or MSE between student, teacher, and true label predictions.

Key Changes:
- Added configurations for these schedulers in `src/config.py`.
- Implemented the scheduler logic in `src/schedulers.py`.
- Updated the scheduler factory `get_alpha_scheduler` to instantiate them.
- Added corresponding command-line arguments in `main.py`.
- Created comprehensive unit tests for all new schedulers in `tests/test_schedulers.py`.
- Provided `alpha_scheduler_testing_examples.md` with example commands for verification.

These enhancements allow for more sophisticated control of the RDT process, potentially improving student model performance by adapting the distillation strategy dynamically.